### PR TITLE
Update `setup-qemu-action` version to v2

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -39,7 +39,7 @@ jobs:
         julia --project=. -e 'using Pkg; Pkg.instantiate()'
         julia --project=. create-snapcraft-yaml.jl "${{ inputs.release }}"
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v1
+      uses: docker/setup-qemu-action@v2
     - name: Build Snap
       uses: diddlesnaps/snapcraft-multiarch-action@v1
       id: snapcraft


### PR DESCRIPTION
This should hopefully fix the following warning:

> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: docker/setup-qemu-action@v1

There's another warning

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

but it's unclear where it's coming from.