### PR TITLE
Sidestep snapcore/action-publish

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -46,9 +46,8 @@ jobs:
       with:
         architecture: ${{ matrix.platform }}
     - name: Upload and Release
-      uses: snapcore/action-publish@v1
       env:
         SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.STORE_TOKEN }}
-      with:
-        snap: ${{ steps.snapcraft.outputs.snap }}
-        release: ${{ inputs.release == 'lts' && 'lts/stable' || inputs.release }}
+      run: |
+        sudo snap install --classic snapcraft --channel=7.x/stable
+        snapcraft upload ${{ steps.snapcraft.outputs.snap }} --release ${{ inputs.release == 'lts' && 'lts/stable' || inputs.release }}


### PR DESCRIPTION
Publish directly instead of relying on `snapcore/action-publish`. The latter does not allow to configure the channel used for snapcraft, and recent versions (>=8) have dropped support for `core18` which is required for `i386` builds.